### PR TITLE
database.ymlのproduction DB記述を修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -49,6 +49,7 @@ test:
 #
 production:
   <<: *default
-  database: freemarket_sample_55a_production
-  username: freemarket_sample_55a
-  password: <%= ENV['FREEMARKET_SAMPLE_55A_DATABASEPASSWORD'] %>
+  database: <%= Rails.application.credentials.db[:database] %>
+  username: <%= Rails.application.credentials.db[:username] %>
+  password: <%= Rails.application.credentials.db[:password] %>
+  socket: <%= Rails.application.credentials.db[:socket] %>


### PR DESCRIPTION
[what]
本番環境でcredentials.yml.encが読み込まれるように設定する

[why]
デプロイ時に発生したmysql2に接続できない不具合を修正するため