### PR TITLE
Capistrano バージョン指定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry-rails'
-  gem 'capistrano'
+  gem 'capistrano', '3.11.1'
   gem 'capistrano-rbenv'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'


### PR DESCRIPTION
＃WHAT
capistranoのバージョンを固定する。

＃WHY
config/deploy.rb で指定したバージョンとbundle installで入ったバージョンが食い違い自動デプロイが失敗する。
これを解決するため。