### PR TITLE
Update gemfile.lock for capistrano 3.11.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrussh (1.3.4)
+    airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
@@ -56,7 +56,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
-    capistrano (3.11.2)
+    capistrano (3.11.1)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -351,7 +351,7 @@ DEPENDENCIES
   bcrypt_pbkdf
   bootsnap (>= 1.1.0)
   byebug
-  capistrano
+  capistrano (= 3.11.1)
   capistrano-bundler
   capistrano-rails
   capistrano-rbenv


### PR DESCRIPTION
# WHAT
gemfile.lockをCapistrano3.11.1を使用する記述に変更されたものをmasterに入れる

# WHY
gemfile.lock記載のバージョンと食い違いが起こりCapistranoによる自動デプロイが失敗するのでこれを解決するため