### PR TITLE
ユーザー本人確認ページ パーシャルパス修正 

### DIFF
--- a/app/views/users/_identification_main.html.haml
+++ b/app/views/users/_identification_main.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'mypage_side'
+= render partial: 'shared/mypage_side'
 .identification-main
   %h2.identification-main__title 本人情報の登録
   = form_with url: "#", class: "identification-form" do |form|

--- a/app/views/users/user_identification.html.haml
+++ b/app/views/users/user_identification.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'shared/main-header'
-= render partial: "bread_crumb"
+= render partial: "shared/bread_crumb"
 %main
   = render partial: 'identification_main'
   = render partial: 'shared/sell-button'


### PR DESCRIPTION
# WHAT
本人情報ページのビューのパーシャル部のパスを修正

#WHY
正常にページが表示できる様にするため