### PR TITLE
マイページのimgタグをimage_tagに変換

### DIFF
--- a/app/assets/stylesheets/modules/_mypage_main.scss
+++ b/app/assets/stylesheets/modules/_mypage_main.scss
@@ -5,7 +5,7 @@
   /* マイページ */
   &__header{
     height: 200px;
-    background: url(/assets/user-bg.jpg);
+    background: image-url("user-bg.jpg"); 
     position: relative;
     .mystore-name-edit{
       padding: 70px 16px 30px;

--- a/app/assets/stylesheets/modules/_mypage_tab-contents.scss
+++ b/app/assets/stylesheets/modules/_mypage_tab-contents.scss
@@ -68,7 +68,7 @@
     }
   }
   .notice__none{
-    background: url(/assets/logo-gray-icon.svg);
+    background: image-url("logo-gray-icon.svg");
     background-size: 80px;
     background-repeat: no-repeat;
     background-position: 50% 25%;

--- a/app/views/users/_identification_main.html.haml
+++ b/app/views/users/_identification_main.html.haml
@@ -1,4 +1,4 @@
-= render partial: 'mypage_side'
+= render partial: 'shared/mypage_side'
 .identification-main
   %h2.identification-main__title 本人情報の登録
   = form_with url: "#", class: "identification-form" do |form|

--- a/app/views/users/_mypage_user_header.html.haml
+++ b/app/views/users/_mypage_user_header.html.haml
@@ -1,7 +1,7 @@
 %section.mypage-main__header
   %a.mystore-link{href: ""}
     %figure.mystore-link__image
-      %img.mystore-link__image_icon{alt: "", src: "/assets/member_photo_noimage_thumb.png"}
+      = image_tag "member_photo_noimage_thumb.png",class:"mystore-link__image_icon", alt: ""
     %h2.mystore-link__name ユーザー名
     .mystore-link__count
       %span 評価 

--- a/app/views/users/_mypage_user_header.html.haml
+++ b/app/views/users/_mypage_user_header.html.haml
@@ -1,5 +1,5 @@
 %section.mypage-main__header
-  %a.mystore-link{href: ""}
+  = link_to "",class:"mystore-link" do
     %figure.mystore-link__image
       = image_tag "member_photo_noimage_thumb.png",class:"mystore-link__image_icon", alt: ""
     %h2.mystore-link__name ユーザー名

--- a/app/views/users/_notice_lists.html.haml
+++ b/app/views/users/_notice_lists.html.haml
@@ -1,7 +1,7 @@
 %ul.show
   %li.notice
     = link_to "",class:"notice__link " do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 事務所からの個別メッセージ
         %span.notice__link-message__passed
@@ -10,7 +10,7 @@
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link " do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 事務所からの個別メッセージ
         %span.notice__link-message__passed
@@ -19,7 +19,7 @@
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 事務所からの個別メッセージ
         %span.notice__link-message__passed
@@ -28,7 +28,7 @@
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: "" 
       .notice__link-message
         %p 事務所からの個別メッセージ
         %span.notice__link-message__passed

--- a/app/views/users/_task_lists.html.haml
+++ b/app/views/users/_task_lists.html.haml
@@ -1,7 +1,7 @@
 %ul
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p まゆたさんから「商品名」の取引メッセージがあります。返信をお願いします
         %span.notice__link-message__passed
@@ -10,7 +10,7 @@
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p まゆたさんが「商品名」を購入しました。内容確認の上、発送をお願いします。
         %span.notice__link-message__passed
@@ -19,7 +19,7 @@
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link " do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p まゆたさんが「商品名」を購入しました。内容確認の上、発送をお願いします。
         %span.notice__link-message__passed
@@ -28,7 +28,7 @@
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p まゆたさんが「商品名」を購入しました。内容確認の上、発送をお願いします。
         %span.notice__link-message__passed

--- a/app/views/users/_traded_lists.html.haml
+++ b/app/views/users/_traded_lists.html.haml
@@ -1,28 +1,28 @@
 %ul
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}/
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 「商品名」を購入しました。取引が完了しました
         %span.notice__link-message__tag.gray 取引完了
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}/
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 「商品名」を購入しました。取引が完了しました
         %span.notice__link-message__tag.gray 取引完了
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 「商品名」を購入しました。取引が完了しました
         %span.notice__link-message__tag.gray 取引完了
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 「商品名」を購入しました。取引が完了しました
         %span.notice__link-message__tag.gray 取引完了

--- a/app/views/users/_trading_lists.html.haml
+++ b/app/views/users/_trading_lists.html.haml
@@ -1,28 +1,28 @@
 %ul.show
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 「商品名」を購入しました。発送をお待ちください
         %span.notice__link-message__tag.blue 発送待ち
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 「商品名」の支払いをしてください。
         %span.notice__link-message__tag.red 支払い待ち
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 「商品名」の取引が完了しました。受取評価をしてください。
         %span.notice__link-message__tag.red 受取評価待ち
       = fa_icon 'chevron-right', class:"mypage-notice_arrow_right"
   %li.notice
     = link_to "",class:"notice__link" do
-      %img.notice__link_img{alt: "", src: "/assets/mercari_profile_icon.png"}
+      = image_tag "mercari_profile_icon.png", class:"notice__link_img", alt: ""
       .notice__link-message
         %p 「商品名」の取引が完了しました。受取評価をしてください。
         %span.notice__link-message__tag.red 受取評価待ち

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -19,7 +19,7 @@
         %h2.header_title
           プロフィール
         .mystore-name-edit
-          %img.mystore_icon{src: "/assets/member_photo_noimage_thumb.png"}
+          = image_tag "member_photo_noimage_thumb.png", class:"mystore_icon"
           %input.input{name:"nickname",placeholder: "",type:"text"}
       .profile
         %textarea.profile_textarea{name:"introduction", placeholder:"例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"}

--- a/app/views/users/user_identification.html.haml
+++ b/app/views/users/user_identification.html.haml
@@ -1,5 +1,5 @@
 = render partial: 'shared/main-header'
-= render partial: "bread_crumb"
+= render partial: "shared/bread_crumb"
 %main
   = render partial: 'identification_main'
   = render partial: 'shared/sell-button'


### PR DESCRIPTION
# what
<img>タグを = image_tagに変更
scssのbackgroud: url(画像パス)を background: image-url("画像")に変更

# why
本番環境では表示されないため、その改善のために実施