### PR TITLE
registrations#step6　「メルカリを始める」ボタンの修正

### DIFF
--- a/app/assets/stylesheets/modules/_rgs-main.scss
+++ b/app/assets/stylesheets/modules/_rgs-main.scss
@@ -169,6 +169,9 @@
       }
     }
     .btn-default {
+      display:block;
+      line-height: 48px;
+      text-align: center;
       width: 100%;
       height: 50px;
       background-color: #E93F36;

--- a/app/views/registrations/step6.html.haml
+++ b/app/views/registrations/step6.html.haml
@@ -10,7 +10,7 @@
           %p
             会員登録が完了しました
           .form__upper__group
-            = button_tag root_path, class:"btn-default" do
+            = link_to root_path, class:"btn-default" do
               メルカリを始める
   = image_tag 'footer.png', alt: 'mercari'
   =render "sub-footer"


### PR DESCRIPTION
＃What
registrations#step6の「メルカリを始める」ボタンが機能していなかった。roots_pathに飛ぶように修正
＃Why
ユーザビリティ向上の為