### PR TITLE
Product#showにおいて、商品サイズの表示

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -40,6 +40,11 @@
           %th ブランド
           %td.brand
             = link_to @product.brand.name, "",class: 'brand__name' if @product.brand.present?
+        - if @product.size.present?
+          %tr
+            %th 商品のサイズ
+            %td.size
+              = @product.size
         %tr
           %th 商品の状態
           %td 


### PR DESCRIPTION
## what
商品サイズがある場合のみ、商品詳細（Product#show）で
商品サイズ項目を表示させる
https://gyazo.com/696523fffef0fb60e6df5e18531cc730

## why
購入したいユーザーに商品サイズをわかりやすくするため
