### PR TITLE
postalcodeのカラムのデータ型変更

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -97,7 +97,7 @@ class ProductsController < ApplicationController
           @address = current_user.address 
           @address_full = "#{@address.prefecture.name}#{@address.city_name}#{@address.address_number}#{@address.building_name}"
           @full_name = "#{@address.firstname} #{@address.lastname}"
-          @postalcode = @address.postalcode
+          @postalcode = @address.postalcode.insert(3, '-')
         end
         @card = Creditcard.where(user_id: current_user.id).first if Creditcard.where(user_id: current_user.id).present?
         if @card.present?

--- a/db/migrate/20191129155314_change_datatype_postalcode_of_addresses.rb
+++ b/db/migrate/20191129155314_change_datatype_postalcode_of_addresses.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypePostalcodeOfAddresses < ActiveRecord::Migration[5.2]
+  def change
+    change_column :addresses, :postalcode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2019_11_17_102628) do
-
+ActiveRecord::Schema.define(version: 2019_11_29_155314) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "firstname", null: false
     t.string "lastname", null: false
     t.string "firstname_kana", null: false
     t.string "lastname_kana", null: false
-    t.integer "postalcode", null: false
+    t.string "postalcode", null: false
     t.integer "prefecture_id", null: false
     t.string "city_name", null: false
     t.string "address_number", null: false


### PR DESCRIPTION
# What
addressesテーブルpostalcodeカラムのデータ型をintegerからstringに変更した。

# Why
郵便番号をviewで表示する際、ハイフンをinsertするとinteger型なのでエラーが出るため。