### PR TITLE
ブランド更新

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -69,6 +69,12 @@ class ProductsController < ApplicationController
 
   def update
     @parents = Category.where(ancestry: nil)
+    
+    unless params[:product][:brand_attributes][:name].nil?
+      brand_name = params[:product][:brand_attributes][:name] 
+      brand = Brand.where(name: brand_name).first_or_create
+      @product[:brand_id] = brand.id
+    end
     if params[:product].keys.include?("image") || params[:product].keys.include?("images_attributes") 
       if @product.valid?
         if params[:product].keys.include?("image")
@@ -80,7 +86,7 @@ class ProductsController < ApplicationController
         @product.update(product_params)
         @size = @product.categories[1].sizes[0]
         @product.update(size: nil) unless @size
-        redirect_to users_path, notice: "商品を更新しました"
+        redirect_to item_product_path(@product), notice: "商品を更新しました"
       else
         render 'edit'
       end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -75,6 +75,10 @@ class ProductsController < ApplicationController
       brand = Brand.where(name: brand_name).first_or_create
       @product[:brand_id] = brand.id
       params[:product][:brand_attributes][:id] = brand.id
+    else
+      @brand = @product.build_brand
+      @product.brand.delete
+      params[:product].delete(:brand_attributes)
     end
     if params[:product].keys.include?("image") || params[:product].keys.include?("images_attributes") 
       if @product.valid?

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -70,7 +70,7 @@ class ProductsController < ApplicationController
   def update
     @parents = Category.where(ancestry: nil)
     
-    unless params[:product][:brand_attributes][:name].nil?
+    unless params[:product][:brand_attributes][:name].blank?
       brand_name = params[:product][:brand_attributes][:name] 
       brand = Brand.where(name: brand_name).first_or_create
       @product[:brand_id] = brand.id

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -74,6 +74,7 @@ class ProductsController < ApplicationController
       brand_name = params[:product][:brand_attributes][:name] 
       brand = Brand.where(name: brand_name).first_or_create
       @product[:brand_id] = brand.id
+      params[:product][:brand_attributes][:id] = brand.id
     end
     if params[:product].keys.include?("image") || params[:product].keys.include?("images_attributes") 
       if @product.valid?

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -56,7 +56,6 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    @product = Product.find(params[:id])
     @parent = @product.categories[0]
     @child = @product.categories[1]
     @grandchild = @product.categories[2]
@@ -65,6 +64,7 @@ class ProductsController < ApplicationController
     @grandchildren = Category.where(ancestry: @grandchild.ancestry)
     @size = @child.sizes[0] if @child.sizes[0]
     @sizes = @size.children if @size
+    @brand = @product.build_brand unless @product.brand.present?
   end
 
   def update

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -169,7 +169,7 @@ class ProductsController < ApplicationController
       :shipping_days,
       :price,
       images_attributes: [:name, :id],
-      brand_attributes: [:name],
+      brand_attributes: [:name, :id],
       category_ids: []
     )
     .merge(seller_id: current_user.id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -70,16 +70,6 @@ class ProductsController < ApplicationController
   def update
     @parents = Category.where(ancestry: nil)
     
-    unless params[:product][:brand_attributes][:name].blank?
-      brand_name = params[:product][:brand_attributes][:name] 
-      brand = Brand.where(name: brand_name).first_or_create
-      @product[:brand_id] = brand.id
-      params[:product][:brand_attributes][:id] = brand.id
-    else
-      @brand = @product.build_brand
-      @product.brand.delete
-      params[:product].delete(:brand_attributes)
-    end
     if params[:product].keys.include?("image") || params[:product].keys.include?("images_attributes") 
       if @product.valid?
         if params[:product].keys.include?("image")
@@ -87,6 +77,16 @@ class ProductsController < ApplicationController
           @product.images.ids.each do |img_id|
             Image.find(img_id).destroy unless posted_image_ids.include?("#{img_id}")
           end
+        end
+        unless params[:product][:brand_attributes][:name].blank?
+          brand_name = params[:product][:brand_attributes][:name] 
+          brand = Brand.where(name: brand_name).first_or_create
+          @product[:brand_id] = brand.id
+          params[:product][:brand_attributes][:id] = brand.id
+        else
+          @brand = @product.build_brand
+          @product.brand.delete
+          params[:product].delete(:brand_attributes)
         end
         @product.update(product_params)
         @size = @product.categories[1].sizes[0]

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -69,7 +69,6 @@ class ProductsController < ApplicationController
 
   def update
     @parents = Category.where(ancestry: nil)
-    
     if params[:product].keys.include?("image") || params[:product].keys.include?("images_attributes") 
       if @product.valid?
         if params[:product].keys.include?("image")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,8 +50,6 @@ Rails.application.routes.draw do
   resources :creditcards, only: [:index, :destroy]
   resources :likes, only: [:index, :create, :destroy]
   
-  get 'login', to: 'registrations#login'
-  
   resources :registrations do
     collection do
       get  'step1'


### PR DESCRIPTION
## 機能（what） 
Product#editによるブランド更新機能実装。
- ブランド名が同じ状態で商品更新しても同じブランド名が複製されない。
- 商品更新時に別のブランド名に更新しても、元のブランド名は更新されず、同じ名前のブランチを検索してそのブランド.idに変更する。
- ブランド名を消した場合、nullにすることができる。


## 目的（why）
### 更新時に重複したブランド名を生成しないため。
問題点1：productを更新すると、brandが重複して生成される。
product_paramsにbrand[:id]も含ませて、brandも更新させる必要がある。

### ブランド名を更新、消去させるため。
問題点2：@product.update(product_params)を実行すると、ブランド名も更新されてしまい、別ユーザーの出品商品のブランド名も変わってしまう。
そのため、”.first_or_create”を利用して、dbに同じ名前がないか検索をさせて、そのidに更新させる。
同じ名前に更新させるので、brandには影響がなく、product.brand.idのみ更新される。

またブランド名を消したい要望がある際に備えて、nullにできるようにしている。


## 仕組み（contrivance）


```
if @product.valid?
        unless params[:product][:brand_attributes][:name].blank? 
          brand_name = params[:product][:brand_attributes][:name] 
          brand = Brand.where(name: brand_name).first_or_create
          @product[:brand_id] = brand.id
          params[:product][:brand_attributes][:id] = brand.id
        else
          @brand = @product.build_brand
          @product.brand.delete
          params[:product].delete(:brand_attributes)
        end
end
```
### ブランド名がある場合
 params[:product][:brand_attributes][:name].blank? により、paramsに含まれているbrand名が空かどうか判定をしている。

```
          brand_name = params[:product][:brand_attributes][:name] 
          brand = Brand.where(name: brand_name).first_or_create
          @product[:brand_id] = brand.id
          params[:product][:brand_attributes][:id] = brand.id
```
ブランド名がある場合、@productとparamsのbrand.idを更新させる。
```
 brand_name = params[:product][:brand_attributes][:name] でparamsよりブランド名を取得する。
```

”.first_or_create”を利用して、dbに同じ名前がないか検索する。dbより同じ名前のbrandを取得し、存在しない場合は新しくbrandモデルを生成する。

```
          brand = Brand.where(name: brand_name).first_or_create
```

そして取得したbrandでproduct.brand.idとparamsのbrand[:id]を更新させる
```
@product[:brand_id] = brand.id
params[:product][:brand_attributes][:id] = brand.id
```


### ブランド名がない場合
@product.update(product_params)でupdateする場合、更新先のidがnullの場合エラーになってしまう。ブランドを一度削除しなければnullにできない。

しかし、ブランドは他のユーザーも利用しているため、@product.brand.deleteを使用できない。
そのため、@product.build_brandで誰も利用していないbrandを新規作成してしまい、それを@product.brand.deleteで削除する。
```
@brand = @product.build_brand
@product.brand.delete
 params[:product].delete(:brand_attributes)
```
@product.update(product_params)となっているため、paramsからもbrand情報を削除しなければ、削除前の元のブランド名に更新されてしまう。
そのため、 params[:product].delete(:brand_attributes)で
paramsのbrand情報も削除する。

これで完全に@productに紐づくbrandは存在しないので、@product.update(product_params)でbrand_id nullになる。